### PR TITLE
Support relative plugin paths

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -32,8 +32,8 @@
     },
 
     "plugins": [
-      "./logger",
-      "./fs"
+      "logger",
+      "fs"
     ],
 
     "redis": {

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -2,6 +2,7 @@
 
 // --- Dependencies ---
 var assert = require('assert');
+var path = require('path');
 
 var debug = require('debug')('arkivo:plugin');
 var trace = require('debug')('arkivo:trace');
@@ -121,22 +122,21 @@ Plugins.prototype.update = function () {
         debug('loading "%s"...', plugin);
 
         var module;
-        var path = plugin;
-        if (path[0] === '.') {
+        if (path.isAbsolute(plugin)) {
+          // If an absolute path, just use it.
+          module = require(plugin);
+        } else if (plugin[0] === '.') {
           // If a relative path, look into the current execution dir.
-          path = process.cwd() + '/' + path;
-          module = require(path);
-        } else if (path[0] === '/') {
-          // If a full path, just use it.
-          module = require(path);
+          module = require(path.join(process.cwd(), plugin));
         } else {
-          // If without a path, try to firstly look into the bundled plugin dir.
+          // If without a path, try to firstly look into
+          // the bundled plugin dir (current dir).
           try {
-            module = require('./' + path);
+            module = require(path.join(__dirname, plugin));
           } catch (error) {
             if (error.code === 'MODULE_NOT_FOUND') {
-              // Then let 'require' to find it.
-              module = require(path);
+              // Let 'require' to find it.
+              module = require(plugin);
             } else {
               throw error;
             }

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -119,8 +119,31 @@ Plugins.prototype.update = function () {
         plugin = config.plugins[i];
 
         debug('loading "%s"...', plugin);
-        this.add(require(plugin));
 
+        var module;
+        var path = plugin;
+        if (path[0] === '.') {
+          // If a relative path, look into the current execution dir.
+          path = process.cwd() + '/' + path;
+          module = require(path);
+        } else if (path[0] === '/') {
+          // If a full path, just use it.
+          module = require(path);
+        } else {
+          // If without a path, try to firstly look into the bundled plugin dir.
+          try {
+            module = require('./' + path);
+          } catch (error) {
+            if (error.code === 'MODULE_NOT_FOUND') {
+              // Then let 'require' to find it.
+              module = require(path);
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        this.add(module);
       } catch (error) {
         debug('failed to load "%s": %s', plugin, error.message);
         trace(error.stack);


### PR DESCRIPTION
`./plugin` - will search the plugin in the current working dir.
`plugin` - firstly looks into arkivo/lib/plugins/ and if not found, it will try to find the plugin in default 'require' paths.
`/full/path/to/plugin` - just uses the path.

This can break other things, therefore must be appropriately tested. Especially if 'logger' and 'fs' plugins were used.
