### PR TITLE
Allow config mutability for tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,6 +3,8 @@ BIN = ./node_modules/.bin
 SRC = lib/*.js lib/**/*.js
 TEST = test/*.js test/*.js test/http/*.js test/plugins/*.js
 
+export ALLOW_CONFIG_MUTATIONS = 1
+
 doc:
 	${BIN}/yuidoc .
 


### PR DESCRIPTION
`config` module makes all configuration immutable after calling `get` for the first time. This is ok and understandable why - no reason to modify config in the middle of script execution.

The config test is executed after many other tests which called `get` on config object and made that config object immutable, therefore `ALLOW_CONFIG_MUTATIONS` environmental variable is added for tests to allow mutations at any time.

Or maybe we don't need that config test?