### PR TITLE
Prevent passing undefined 'timestamp' variable to redis HMSET

### DIFF
--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -63,7 +63,7 @@ function Subscription(values) {
    * @property timestamp
    * @type String
    */
-  var timestamp;
+  var timestamp = 0;
 
   property(this, 'timestamp', {
     enumerable: true,


### PR DESCRIPTION
Prevent passing undefined 'timestamp' variable to redis HMSET to fix:
> node_redis: Deprecated: The HMSET command contains a "undefined" argument.
> This is converted to a "undefined" string now and will return an error from v.3.0 on.
> Please handle this in your code to make sure everything works as you intended it to.